### PR TITLE
fix: firefox ext packager is not including dir content recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store 
 node_module
 firefox
+mahsa-amini-hashflag-firefox.zip

--- a/pack-firefox.sh
+++ b/pack-firefox.sh
@@ -1,8 +1,7 @@
 mkdir firefox
 cp manifest.firefox.json firefox/manifest.json
-cp -R images js firefox /
+cp -R images js firefox
 cd firefox
-zip mahsa-amini-hashflag-firefox.zip *
+zip -r ../mahsa-amini-hashflag-firefox.zip *
 cd ..
-cp firefox/mahsa-amini-hashflag-firefox.zip .
 rm -r firefox


### PR DESCRIPTION
Firefox extension packager is not including `js` and `images` directories content recursively. This PR fixes the bash script for this and make it a bit simpler.